### PR TITLE
Fix Dockerfile

### DIFF
--- a/examples/redis/Dockerfile
+++ b/examples/redis/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:latest 
+FROM alpine:3.16 
 
-RUN apk add bash curl redis python py-pip jq
+RUN apk add bash curl redis python3 py3-pip jq
 RUN pip install yq
 
 RUN curl -L https://github.com/rtctunnel/rtctunnel/releases/download/v0.3.0/rtctunnel_linux_amd64.tar.gz \


### PR DESCRIPTION
- Freeze Alpine version to 3.16 (latest)
- Using python3 and py3-pip packages (See docker-library/docker#240 for more information.)